### PR TITLE
fix: coerce undefined body to null

### DIFF
--- a/.changeset/mighty-rings-whisper.md
+++ b/.changeset/mighty-rings-whisper.md
@@ -1,0 +1,5 @@
+---
+"@cuppachino/openapi-fetch": patch
+---
+
+fix: coerce undefined body to null (stricter dev types)

--- a/src/index.ts
+++ b/src/index.ts
@@ -328,12 +328,23 @@ function wrapMiddlewares(middlewares: Middleware[], fetch: Fetch): Fetch {
   return (url, init) => handler(0, url, init)
 }
 
+const preferNull = <T>(
+  maybe: T | undefined | null,
+): Exclude<T, undefined> | null => {
+  if (maybe === undefined) return null
+  return maybe as Exclude<T, undefined>
+}
+
 async function fetchUrl<R>(request: Request) {
-  const { url, init } = getFetchParams(request)
+  const {
+    init: { body, ...init },
+    url,
+  } = getFetchParams(request)
 
-  const response = await request.fetch(url, init)
-
-  return response as ApiResponse<R>
+  return (await request.fetch(url, {
+    ...init,
+    body: preferNull(body),
+  })) as ApiResponse<R>
 }
 
 function createFetch<OP>(fetch: _TypedFetch<OP>): TypedFetch<OP> {

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -266,7 +266,7 @@ describe('fetch', () => {
     })
 
     expect(data.body.list).toEqual(['b', 'c', 'mw2', 'mw1'])
-    expect(data.headers.mw1).toEqual('true')
+    expect(data.headers['mw1']).toEqual('true')
     expect(captured.url).toEqual('https://api.backend.dev/bodyquery/1?scalar=a')
     expect(captured.body).toEqual('{"list":["b","c"]}')
   })

--- a/test/mocks/handlers.ts
+++ b/test/mocks/handlers.ts
@@ -51,7 +51,7 @@ const methods = {
   }),
   withError: [
     rest.get(`${HOST}/error/:status`, (req, res, ctx) => {
-      const status = Number(req.params.status)
+      const status = Number(req.params['status'])
       const detail = req.url.searchParams.get('detail') === 'true'
       return detail
         ? res(
@@ -64,13 +64,13 @@ const methods = {
           )
         : res(ctx.status(status))
     }),
-    rest.post(`${HOST}/nocontent`, (req, res, ctx) => {
+    rest.post(`${HOST}/nocontent`, (_, res, ctx) => {
       return res(ctx.status(204))
     }),
-    rest.get(`${HOST}/defaulterror`, (req, res, ctx) => {
+    rest.get(`${HOST}/defaulterror`, (_, res, ctx) => {
       return res(ctx.status(500), ctx.body('internal server error'))
     }),
-    rest.get(`${HOST}/networkerror`, (req, res) => {
+    rest.get(`${HOST}/networkerror`, (_, res) => {
       return res.networkError('failed to connect')
     }),
   ],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -11,7 +11,13 @@
       "sourceMap": false,
       "strict": true,
       "target": "ES2015",
-      "useDefineForClassFields": true
+      "useDefineForClassFields": true,
+      "exactOptionalPropertyTypes": true,
+      "noImplicitOverride": true,
+      "noPropertyAccessFromIndexSignature": true,
+      "noUnusedLocals": true,
+      "noUnusedParameters": true,
+      "isolatedModules": true,
     },
     "include": ["src"]
   }


### PR DESCRIPTION
Toggled on a few TS rules and fixed the errors. The only real code change is that `undefined` `body`s are now explicitly coerced to `null`.