### PR TITLE
fix: main fallback to correct cjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "author": "Ajai Shankar",
   "license": "MIT",
   "type": "module",
-  "main": "./dist/cjs/index.js",
+  "main": "./dist/cjs/index.cjs",
   "module": "./dist/esm/index.js",
   "exports": {
     "types": "./dist/index.d.ts",


### PR DESCRIPTION
Environments that don't have support for `exports` will look to the `main` field for the package entry point. We should probably fallback to cjs for these older targets.

note: this could be wrong because the type is module, but from testing with electron, this is worked when previously it didn't.